### PR TITLE
Add Quicksand font and cozy palette variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+      <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;700&display=swap" rel="stylesheet">
   </head>
 
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,11 @@ All colors MUST be HSL.
     --input: 233 14% 49%;
     --ring: 29 70% 52%;
 
+    --sky: 225 18% 38%;
+    --moon: 35 72% 85%;
+    --reflection: 233 14% 49%;
+    --accent-fox: 29 70% 52%;
+
     --radius: 0.75rem;
 
     --sidebar-background: 225 18% 38%;
@@ -117,7 +122,7 @@ All colors MUST be HSL.
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-cozy;
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,6 +18,7 @@ export default {
 			}
 		},
                 extend: {
+                        fontFamily: { cozy: ['"Quicksand"', 'sans-serif'] },
                         colors: {
                                 border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',


### PR DESCRIPTION
## Summary
- link Quicksand font in HTML
- add `cozy` font family to Tailwind config
- define new CSS palette variables and apply cozy font to body

## Testing
- `npm run lint` *(fails: no-empty, no-explicit-any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6894dc4695e88329a31bc4e4c0f41473