### PR TITLE
Wrap index page in CozyScene and reposition start button

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 import { Helmet } from "react-helmet-async";
 import { Button } from "@/components/ui/button";
+import { CozyScene } from "@/components/CozyScene";
 import { Link } from "react-router-dom";
 
 const Index = () => {
@@ -10,19 +11,25 @@ const Index = () => {
         <meta name="description" content="Responde 16 preguntas y descubre qué libro del club coincide con tu personalidad lectora." />
         <link rel="canonical" href="/" />
       </Helmet>
-      <header className="relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-primary opacity-20" aria-hidden="true" />
+      <CozyScene>
+        <Link to="/quiz">
+          <Button
+            variant="hero"
+            className="absolute top-32 right-4 px-8 py-6 text-base animate-floaty text-primary-foreground"
+          >
+            Comenzar
+          </Button>
+        </Link>
         <section className="container min-h-[70vh] flex items-center">
           <div className="mx-auto text-center max-w-3xl py-16">
             <h1 className="text-4xl sm:text-6xl font-bold tracking-tight mb-6">¿Qué libro del club eres?</h1>
             <p className="text-lg sm:text-xl text-muted-foreground mb-8">Un test de 16 preguntas inspirado en MBTI para recomendarte el título perfecto según tu estilo lector. Rápido, divertido y pensado para club de lectura.</p>
-            <div className="flex items-center justify-center gap-4">
-              <Link to="/quiz"><Button variant="hero" className="px-8 py-6 text-base animate-floaty">Comenzar</Button></Link>
+            <div className="flex items-center justify-center">
               <Link to="/admin"><Button variant="outline">Editar catálogo</Button></Link>
             </div>
           </div>
         </section>
-      </header>
+      </CozyScene>
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- Replace header with CozyScene on the index page
- Move "Comenzar" button below moon and use `hero` variant

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894e070138c8329a43a42d323a63109