### PR TITLE
feat: add night beach theme

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,17 +5,17 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background text-card-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "bg-card text-card-foreground hover:bg-card/90",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-card text-card-foreground hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "bg-card text-card-foreground hover:bg-card/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         hero:

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -42,14 +42,14 @@ export default function Quiz() {
   const q = questions[current];
 
   return (
-    <main className="min-h-screen bg-gradient-subtle">
+    <main className="min-h-screen bg-gradient-night flex flex-col">
       <Helmet>
         <title>Test lector – ¿Qué libro del club eres?</title>
         <meta name="description" content="Responde 16 preguntas y descubre tu tipo lector MBTI y tu libro ideal del club." />
         <link rel="canonical" href="/quiz" />
       </Helmet>
 
-      <section className="container py-10 sm:py-16">
+      <section className="container py-10 sm:py-16 flex-1">
         <div className="max-w-3xl mx-auto">
           <Card className="shadow-elegant">
             <CardHeader>
@@ -84,6 +84,7 @@ export default function Quiz() {
           </Card>
         </div>
       </section>
+      <div className="h-[20vh] bg-gradient-reflection" aria-hidden="true" />
     </main>
   );
 }

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -34,9 +34,12 @@ export default function Result() {
 
   if (!resumen) {
     return (
-      <main className="min-h-screen flex items-center justify-center">
-        <p className="text-muted-foreground">No hay resultado. Comienza el test.</p>
-        <Button className="ml-4" onClick={() => navigate("/")}>Inicio</Button>
+      <main className="min-h-screen bg-gradient-night flex flex-col">
+        <div className="flex-1 flex items-center justify-center">
+          <p className="text-muted-foreground">No hay resultado. Comienza el test.</p>
+          <Button className="ml-4" onClick={() => navigate("/")}>Inicio</Button>
+        </div>
+        <div className="h-[20vh] bg-gradient-reflection" aria-hidden="true" />
       </main>
     );
   }
@@ -52,7 +55,7 @@ export default function Result() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-subtle">
+    <main className="min-h-screen bg-gradient-night flex flex-col">
       <Helmet>
         <title>Resultado – {resumen.selected.titulo}</title>
         <meta name="description" content={`Tu tipo ${resumen.mbti} y tu libro recomendado: ${resumen.selected.titulo}.`} />
@@ -60,7 +63,7 @@ export default function Result() {
         <script type="application/ld+json">{JSON.stringify(bookLd)}</script>
       </Helmet>
 
-      <section className="container py-10 sm:py-16">
+      <section className="container py-10 sm:py-16 flex-1">
         <div className="max-w-3xl mx-auto">
           <Card className="shadow-elegant">
             <CardHeader>
@@ -91,6 +94,7 @@ export default function Result() {
           </Card>
         </div>
       </section>
+      <div className="h-[20vh] bg-gradient-reflection" aria-hidden="true" />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- switch quiz and result pages to night gradient with reflective water footer
- use card palette for default buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 7 errors, 7 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894eb4518188329b86a91347cfa9213