### PR TITLE
feat: add parallax hook and animations

### DIFF
--- a/src/components/CozyScene.tsx
+++ b/src/components/CozyScene.tsx
@@ -1,10 +1,13 @@
 import type { ReactNode } from "react";
+import { useParallax } from "./hooks/useParallax";
 
 interface CozySceneProps {
   children?: ReactNode;
 }
 
 export function CozyScene({ children }: CozySceneProps) {
+  useParallax();
+
   return (
     <div className="relative w-full overflow-hidden">
       <div className="absolute inset-0 bg-gradient-night -z-20" />
@@ -13,21 +16,25 @@ export function CozyScene({ children }: CozySceneProps) {
         src="/moon.svg"
         alt="Luna"
         className="absolute top-4 right-4 w-24 h-24 z-10"
+        data-speed="-0.1"
       />
       <img
         src="/cypresses.svg"
         alt="Cipreses"
         className="absolute bottom-20 left-0 w-full z-20"
+        data-speed="0.1"
       />
       <img
         src="/rocks.svg"
         alt="Rocas"
         className="absolute bottom-0 left-0 w-full z-30"
+        data-speed="0.2"
       />
       <img
         src="/boy-fox.svg"
         alt="Niño y zorro"
         className="absolute bottom-0 left-1/2 -translate-x-1/2 z-40 w-32"
+        data-speed="0.3"
       />
       <div className="relative z-50">{children}</div>
     </div>

--- a/src/components/hooks/useParallax.ts
+++ b/src/components/hooks/useParallax.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+export function useParallax() {
+  useEffect(() => {
+    const handleScroll = () => {
+      const y = window.scrollY;
+      document.querySelectorAll<HTMLElement>("[data-speed]").forEach((el) => {
+        const speed = Number(el.dataset.speed) || 0;
+        if (!el.dataset.baseTransform) {
+          const cs = getComputedStyle(el).transform;
+          el.dataset.baseTransform = cs === "none" ? "" : cs;
+        }
+        const base = el.dataset.baseTransform ?? "";
+        el.style.transform = `${base} translateY(${y * speed}px)`;
+      });
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+}
+
+export default useParallax;

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -5,10 +5,10 @@ function Skeleton({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
-    <div
-      className={cn("animate-pulse rounded-md bg-muted", className)}
-      {...props}
-    />
+      <div
+        className={cn("animate-bruma rounded-md", className)}
+        {...props}
+      />
   )
 }
 

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -27,7 +27,7 @@ const toastVariants = cva(
   {
     variants: {
       variant: {
-        default: "border bg-background text-foreground",
+          default: "border bg-background text-foreground animate-abrazo",
         destructive:
           "destructive group border-destructive bg-destructive text-destructive-foreground",
       },

--- a/src/index.css
+++ b/src/index.css
@@ -153,4 +153,26 @@ All colors MUST be HSL.
   .animate-floaty {
     animation: floaty 6s ease-in-out infinite;
   }
+  @keyframes bruma {
+    0% { background-position: -200% 0; }
+    100% { background-position: 200% 0; }
+  }
+  .animate-bruma {
+    background-image: linear-gradient(
+      90deg,
+      hsl(var(--muted)) 0%,
+      hsl(var(--muted-foreground)) 50%,
+      hsl(var(--muted)) 100%
+    );
+    background-size: 200% 100%;
+    animation: bruma 1.5s ease-in-out infinite;
+  }
+  @keyframes abrazo {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+    100% { transform: scale(1); }
+  }
+  .animate-abrazo {
+    animation: abrazo 0.6s ease-in-out;
+  }
 }


### PR DESCRIPTION
## Summary
- add custom useParallax hook and apply to CozyScene layers
- define bruma and abrazo animations for shimmer and positive feedback
- integrate shimmer into Skeleton and embrace animation in toasts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 7 errors, 7 warnings)*
- `npx eslint src/components/CozyScene.tsx src/components/hooks/useParallax.ts src/components/ui/skeleton.tsx src/components/ui/toast.tsx && echo 'LINT_OK'`

------
https://chatgpt.com/codex/tasks/task_e_6894ecd32e188329871bc57237ecde9e