### PR TITLE
Center start button on home page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,20 +12,16 @@ const Index = () => {
         <link rel="canonical" href="/" />
       </Helmet>
       <CozyScene>
-        <Link to="/quiz">
-          <Button
-            variant="hero"
-            className="absolute top-32 right-4 px-8 py-6 text-base animate-floaty text-primary-foreground"
-          >
-            Comenzar
-          </Button>
-        </Link>
         <section className="container min-h-[70vh] flex items-center">
           <div className="mx-auto text-center max-w-3xl py-16">
             <h1 className="text-4xl sm:text-6xl font-bold tracking-tight mb-6">¿Qué libro del club eres?</h1>
             <p className="text-lg sm:text-xl text-muted-foreground mb-8">Un test de 16 preguntas inspirado en MBTI para recomendarte el título perfecto según tu estilo lector. Rápido, divertido y pensado para club de lectura.</p>
             <div className="flex items-center justify-center">
-              <Link to="/admin"><Button variant="outline">Editar catálogo</Button></Link>
+              <Link to="/quiz">
+                <Button variant="hero" className="px-8 py-6 text-base">
+                  Comenzar
+                </Button>
+              </Link>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- remove catalog editor button from landing page
- center the "Comenzar" button for a cleaner layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 12 problems (5 errors, 7 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689520b3338483299d805de83d4a7278