### PR TITLE
feat: enlarge mobile quiz option text

### DIFF
--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -63,7 +63,7 @@ export default function Quiz() {
                   <Button
                     key={o.key}
                     variant={answers[q.id] === o.key ? "secondary" : "outline"}
-                    className="justify-start h-auto py-4"
+                    className="justify-start h-auto py-5 text-lg sm:text-xl"
                     onClick={() => onSelect(o.key)}
                     aria-pressed={answers[q.id] === o.key}
                   >


### PR DESCRIPTION
## Summary
- increase option buttons' text size and padding for better mobile readability

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, A require() style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689544e690588329b9cd124ceef9bec9