### PR TITLE
feat: adjust container padding for mobile

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,7 +12,7 @@ export default {
 	theme: {
 		container: {
 			center: true,
-			padding: '2rem',
+                        padding: { DEFAULT: '1rem', md: '2rem' },
 			screens: {
 				'2xl': '1400px'
 			}


### PR DESCRIPTION
## Summary
- make container padding responsive so mobile uses 1rem and md+ uses 2rem

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895470bcef083298101a1eb7144739f