### PR TITLE
feat: full-width layout on mobile

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,7 +13,7 @@ const Index = () => {
       </Helmet>
       <CozyScene>
         <section className="container min-h-[70vh] flex items-center">
-          <div className="mx-auto text-center max-w-3xl py-16">
+          <div className="mx-auto text-center max-w-full md:max-w-3xl py-16">
             <h1 className="text-4xl sm:text-6xl font-bold tracking-tight mb-6">¿Qué libro del club eres?</h1>
             <p className="text-lg sm:text-xl text-muted-foreground mb-8">Un test de 16 preguntas inspirado en MBTI para recomendarte el título perfecto según tu estilo lector. Rápido, divertido y pensado para club de lectura.</p>
             <div className="flex items-center justify-center">

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -50,7 +50,7 @@ export default function Quiz() {
       </Helmet>
 
       <section className="container py-10 sm:py-16 flex-1">
-        <div className="max-w-3xl mx-auto">
+        <div className="max-w-full md:max-w-3xl mx-auto">
           <Card className="shadow-elegant">
             <CardHeader>
               <CardTitle className="text-xl sm:text-2xl">Pregunta {current + 1} de {questions.length}</CardTitle>


### PR DESCRIPTION
## Summary
- ensure Index and Quiz content uses full width on mobile while staying 3xl on larger screens

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; Unexpected any; A `require()` style import is forbidden)*
- `npx eslint src/pages/Index.tsx src/pages/Quiz.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689548dfea608329ad5e33c8b956160a