### PR TITLE
Refactor index layout and extend parallax

### DIFF
--- a/src/components/hooks/useParallax.ts
+++ b/src/components/hooks/useParallax.ts
@@ -4,15 +4,23 @@ export function useParallax() {
   useEffect(() => {
     const handleScroll = () => {
       const y = window.scrollY;
-      document.querySelectorAll<HTMLElement>("[data-speed]").forEach((el) => {
-        const speed = Number(el.dataset.speed) || 0;
-        if (!el.dataset.baseTransform) {
-          const cs = getComputedStyle(el).transform;
-          el.dataset.baseTransform = cs === "none" ? "" : cs;
-        }
-        const base = el.dataset.baseTransform ?? "";
-        el.style.transform = `${base} translateY(${y * speed}px)`;
-      });
+      document
+        .querySelectorAll<HTMLElement>(
+          "[data-speed],[data-speed-x],[data-speed-y]"
+        )
+        .forEach((el) => {
+          const speedX = Number(el.dataset.speedX) || 0;
+          const speedY = Number(el.dataset.speedY || el.dataset.speed) || 0;
+          if (!el.dataset.baseTransform) {
+            const cs = getComputedStyle(el).transform;
+            el.dataset.baseTransform = cs === "none" ? "" : cs;
+          }
+          const base = el.dataset.baseTransform ?? "";
+          const transforms = [base];
+          if (speedX) transforms.push(`translateX(${y * speedX}px)`);
+          if (speedY) transforms.push(`translateY(${y * speedY}px)`);
+          el.style.transform = transforms.join(" ").trim();
+        });
     };
 
     handleScroll();

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,9 +1,10 @@
 import { Helmet } from "react-helmet-async";
 import { Button } from "@/components/ui/button";
-import { CozyScene } from "@/components/CozyScene";
 import { Link } from "react-router-dom";
+import { useParallax } from "@/components/hooks/useParallax";
 
 const Index = () => {
+  useParallax();
   return (
     <main>
       <Helmet>
@@ -11,21 +12,27 @@ const Index = () => {
         <meta name="description" content="Responde 16 preguntas y descubre qué libro del club coincide con tu personalidad lectora." />
         <link rel="canonical" href="/" />
       </Helmet>
-      <CozyScene>
-        <section className="container min-h-[70vh] flex items-center">
-          <div className="mx-auto text-center max-w-full md:max-w-3xl py-16">
-            <h1 className="text-4xl sm:text-6xl font-bold tracking-tight mb-6">¿Qué libro del club eres?</h1>
-            <p className="text-lg sm:text-xl text-muted-foreground mb-8">Un test de 16 preguntas inspirado en MBTI para recomendarte el título perfecto según tu estilo lector. Rápido, divertido y pensado para club de lectura.</p>
-            <div className="flex items-center justify-center">
-              <Link to="/quiz">
-                <Button variant="hero" className="px-8 py-6 text-base">
-                  Comenzar
-                </Button>
-              </Link>
-            </div>
+      <section className="relative h-[60vh] overflow-hidden">
+        <img
+          src="/bg.webp"
+          alt=""
+          data-speed-x="0.05"
+          className="w-full h-full object-cover object-center"
+        />
+      </section>
+      <section className="container flex items-center">
+        <div className="mx-auto text-center max-w-full md:max-w-3xl py-16">
+          <h1 className="text-4xl sm:text-6xl font-bold tracking-tight mb-6">¿Qué libro del club eres?</h1>
+          <p className="text-lg sm:text-xl text-muted-foreground mb-8">Un test de 16 preguntas inspirado en MBTI para recomendarte el título perfecto según tu estilo lector. Rápido, divertido y pensado para club de lectura.</p>
+          <div className="flex items-center justify-center">
+            <Link to="/quiz">
+              <Button variant="hero" className="px-8 py-6 text-base">
+                Comenzar
+              </Button>
+            </Link>
           </div>
-        </section>
-      </CozyScene>
+        </div>
+      </section>
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- Replace CozyScene wrapper with explicit top and bottom sections featuring a parallax background image
- Extend `useParallax` hook to support `data-speed-x` and `data-speed-y` for horizontal and vertical scrolling effects
- Apply horizontal parallax to landing page background image using `data-speed-x="0.05"`

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, A `require()` style import is forbidden)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68954c1a2c2883299b0bf036f1574e9a