### PR TITLE
Use navigate to start quiz and rename route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ const AppRoutes = () => {
     <AnimatePresence mode="wait">
       <Routes location={location} key={location.pathname}>
         <Route path="/" element={<Index />} />
-        <Route path="/quiz" element={<Quiz />} />
+        <Route path="/preguntas" element={<Quiz />} />
         <Route path="/resultado" element={<Result />} />
         <Route path="/admin" element={<Admin />} />
         {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,10 +1,12 @@
 import { Helmet } from "react-helmet-async";
 import { Button } from "@/components/ui/button";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useParallax } from "@/components/hooks/useParallax";
 
 const Index = () => {
   useParallax();
+  const navigate = useNavigate();
+
   return (
     <main>
       <Helmet>
@@ -25,11 +27,13 @@ const Index = () => {
           <h1 className="text-4xl sm:text-6xl font-bold tracking-tight mb-6">¿Qué libro del club eres?</h1>
           <p className="text-lg sm:text-xl text-muted-foreground mb-8">Un test de 16 preguntas inspirado en MBTI para recomendarte el título perfecto según tu estilo lector. Rápido, divertido y pensado para club de lectura.</p>
           <div className="flex items-center justify-center">
-            <Link to="/quiz">
-              <Button variant="hero" className="px-8 py-6 text-base">
-                Comenzar
-              </Button>
-            </Link>
+            <Button
+              variant="hero"
+              className="px-8 py-6 text-base"
+              onClick={() => navigate("/preguntas")}
+            >
+              Comenzar
+            </Button>
           </div>
         </div>
       </section>

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -48,7 +48,7 @@ export default function Quiz() {
         <Helmet>
           <title>Test lector – ¿Qué libro del club eres?</title>
           <meta name="description" content="Responde 16 preguntas y descubre tu tipo lector MBTI y tu libro ideal del club." />
-          <link rel="canonical" href="/quiz" />
+          <link rel="canonical" href="/preguntas" />
         </Helmet>
 
         <section className="container py-10 sm:py-16 flex-1">

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -106,7 +106,7 @@ export default function Result() {
               <p className="text-lg">{frase}</p>
 
               <div className="flex flex-wrap gap-3">
-                <Button variant="secondary" onClick={() => navigate("/quiz")}>Volver a responder</Button>
+                <Button variant="secondary" onClick={() => navigate("/preguntas")}>Volver a responder</Button>
                 <Button variant="hero" onClick={() => navigate("/")}>Volver al inicio</Button>
               </div>
             </CardContent>


### PR DESCRIPTION
## Summary
- Start button now uses `navigate('/preguntas')` instead of a static link.
- Quiz route renamed to `/preguntas` with canonical link update.
- Result page's retry button points back to `/preguntas`.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6895531f1afc8329a6cc0289b2e8fb0f