### PR TITLE
feat: animate stairs with framer motion

### DIFF
--- a/src/components/Stairs/index.jsx
+++ b/src/components/Stairs/index.jsx
@@ -1,21 +1,44 @@
+import { motion } from "framer-motion";
 import { expand, opacity } from "./anim";
 
 const nbOfColumns = 8;
 
+const variants = {
+  initial: { ...expand.initial, ...opacity.initial },
+  animate: {
+    ...expand.animate,
+    ...opacity.animate,
+    transition: {
+      ...expand.animate.transition,
+      ...opacity.animate.transition,
+    },
+  },
+  exit: {
+    ...expand.exit,
+    ...opacity.exit,
+    transition: {
+      ...expand.exit.transition,
+      ...opacity.exit.transition,
+    },
+  },
+};
+
 const Layout = ({ children, backgroundColor }) => {
   return (
-    <div
+    <motion.div
+      className="stairs"
       style={{
-        overflow: "hidden",
-        ...expand.animate,
-        ...opacity.animate,
         backgroundColor,
         display: "grid",
         gridTemplateColumns: `repeat(${nbOfColumns}, 1fr)`,
       }}
+      variants={variants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
     >
       {children}
-    </div>
+    </motion.div>
   );
 };
 


### PR DESCRIPTION
## Summary
- refactor Stairs layout to use framer-motion and combined variants
- ensure quiz transition animates via motion div

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 12 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689557ba466083299e58d9aff72ec506