### PR TITLE
Ensure Stairs children span grid width

### DIFF
--- a/src/components/Stairs/index.jsx
+++ b/src/components/Stairs/index.jsx
@@ -53,7 +53,16 @@ const Layout = ({ children, backgroundColor }) => {
           }}
         />
       ))}
-      {children}
+      <div
+        style={{
+          gridColumn: "1 / -1",
+          gridRow: "1",
+          position: "relative",
+          zIndex: 1,
+        }}
+      >
+        {children}
+      </div>
     </motion.div>
   );
 };


### PR DESCRIPTION
## Summary
- Wrap Stairs children in a full-width div that overlays grid columns

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 12 problems, 5 errors and 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6895613bcee483299d5e4d11695fbd76