### PR TITLE
refactor: update stairs container styles

### DIFF
--- a/src/styles/transition.scss
+++ b/src/styles/transition.scss
@@ -1,6 +1,5 @@
 .stairs {
   overflow: hidden;
-  height: 0;
-  opacity: 0;
-  transition: height 0.3s ease, opacity 0.3s ease;
+  position: relative;
+  height: auto;
 }


### PR DESCRIPTION
## Summary
- remove height/opacity from `.stairs` container and use relative positioning
- rely on column elements for height and opacity animations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895622673d08329a8bbabd7250791ab