### PR TITLE
docs: aclarar respuestas intermedias en la pregunta de clásicos vs novedades

### DIFF
--- a/src/lib/quiz/questions.ts
+++ b/src/lib/quiz/questions.ts
@@ -184,6 +184,8 @@ export const questions: Question[] = [
     id: 16,
     text: "Cuando tienes que elegir entre un clásico y un lanzamiento reciente…",
     pair: "RA",
+    // Las respuestas B (“me inclino hacia libros recientes, pero los clásicos también me atraen”)
+    // y C (“me suelen llamar más los clásicos que los libros de moda”) se tratan como intermedias.
     options: [
       { key: "A", label: "Siempre prefiero las novedades; me gusta lo nuevo." },
       { key: "B", label: "Me inclino hacia libros recientes, pero los clásicos también me atraen." },


### PR DESCRIPTION
## Summary
- aclara que las opciones B y C de la pregunta 16 se consideran respuestas intermedias

## Testing
- `npm test` *(falla: Missing script "test")*
- `npm run lint` *(errores en archivos ajenos)*

------
https://chatgpt.com/codex/tasks/task_e_6895732243c48329a20fadfd148b309c