### PR TITLE
feat: soften button contrast

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,7 +9,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-card text-card-foreground hover:bg-card/90",
+        default:
+          "bg-[hsl(var(--primary-soft))] text-primary-foreground hover:bg-[hsl(var(--primary))]",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:


### PR DESCRIPTION
## Summary
- soften default button coloring for gentler contrast using existing primary palette

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895844c656c83298335020ae5f7f939