### PR TITLE
feat: update quiz option background color

### DIFF
--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -68,6 +68,7 @@ export default function Quiz() {
                       className="justify-start h-auto py-5 text-lg sm:text-xl"
                       onClick={() => onSelect(o.key)}
                       aria-pressed={answers[q.id] === o.key}
+                      style={{ backgroundColor: "#5c9063" }}
                     >
                       <span className="font-semibold mr-2">{o.key})</span>
                       {o.label}


### PR DESCRIPTION
## Summary
- set quiz answer buttons to use green background

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689585fb6c9883299eedb68a81b9aad0