### PR TITLE
Fix stairs transition animation

### DIFF
--- a/src/components/Stairs/anim.js
+++ b/src/components/Stairs/anim.js
@@ -1,6 +1,7 @@
 export const expand = {
   initial: { height: 0 },
-  animate: { height: "auto", transition: { duration: 0.5, delay: 0.2 } },
+  // Use a real height so the columns visibly expand from 0 to full size
+  animate: { height: "100%", transition: { duration: 0.5, delay: 0.2 } },
   exit: { height: 0, transition: { duration: 0.5, delay: 0 } },
 };
 

--- a/src/components/Stairs/index.jsx
+++ b/src/components/Stairs/index.jsx
@@ -50,6 +50,9 @@ const Layout = ({ children, backgroundColor }) => {
           style={{
             backgroundColor,
             gridColumn: `${i + 1} / span 1`,
+            // Give each column visible height and span the full row
+            height: "100%",
+            gridRow: "1 / -1",
           }}
         />
       ))}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,7 +12,10 @@ const Index = () => {
   const [closing, setClosing] = useState(false);
 
   return (
-    <AnimatePresence onExitComplete={() => navigate("/preguntas")}> 
+    <AnimatePresence
+      mode="wait" // ensure exit animation completes before navigating
+      onExitComplete={() => navigate("/preguntas")}
+    >
       {!closing && (
         <Layout backgroundColor="hsl(var(--background))">
           <main>


### PR DESCRIPTION
## Summary
- ensure stair columns expand with visible height and span full container
- wait for exit animation before navigating between pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 12 problems; 5 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6896123b44f88329878cf57d3853708f