### PR TITLE
feat: support optional fun fact in book catalog entries

### DIFF
--- a/src/lib/quiz/scoring.ts
+++ b/src/lib/quiz/scoring.ts
@@ -108,6 +108,7 @@ export interface BookEntry {
   anio: number;
   portada?: string;
   sinopsis?: string;
+  datoCurioso?: string;
 }
 
 export interface CatalogEntry {

--- a/src/lib/results/catalog.ts
+++ b/src/lib/results/catalog.ts
@@ -12,7 +12,7 @@ export const defaultCatalog: Catalog = {
     EI: {
       libros: [
         { titulo: "Fahrenheit 451", anio: 1953 },
-        { titulo: "1984", anio: 1949 },
+        { titulo: "1984", anio: 1949, datoCurioso: "Orwell casi titula la novela 'The Last Man in Europe'" },
         { titulo: "El cuento de la criada", anio: 1985 }
       ],
       texto: "Como ENTJ sociable y orientado a grandes cambios, te gusta enfrentarte a sociedades que necesitan despertar. Tu libro ideal es {titulo}: te hará liderar revoluciones desde tu sillón."
@@ -28,7 +28,7 @@ export const defaultCatalog: Catalog = {
     TF: {
       libros: [
         { titulo: "El cuento de la criada", anio: 1985 },
-        { titulo: "1984", anio: 1949 }
+        { titulo: "1984", anio: 1949, datoCurioso: "Orwell casi titula la novela 'The Last Man in Europe'" }
       ],
       texto: "Eres un ENTJ racional: prefieres tramas que cuestionan el poder con fría inteligencia. {titulo} alimentará tu mente ambiciosa."
     },

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -102,6 +102,11 @@ export default function Result() {
                 />
                 <div>
                   <p className="text-lg font-semibold">{resumen.selected.titulo} <span className="text-muted-foreground">({resumen.selected.anio})</span></p>
+                  {resumen.selected.datoCurioso && (
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      Dato curioso: {resumen.selected.datoCurioso}
+                    </p>
+                  )}
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- allow BookEntry to include an optional `datoCurioso`
- show a book's fun fact on the result page when available
- add sample `datoCurioso` for *1984* in the default catalog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, empty block statement, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6896c7fe8b04832980559aa3509c8d18