### PR TITLE
feat: show synopsis and trivia in result

### DIFF
--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -76,6 +76,12 @@ export default function Result() {
     name: resumen.selected.titulo,
     datePublished: resumen.selected.anio,
     description: resumen.selected.sinopsis ?? resumen.texto,
+    ...(resumen.selected.datoCurioso && {
+      comment: {
+        "@type": "Comment",
+        text: resumen.selected.datoCurioso,
+      },
+    }),
   };
 
   return (
@@ -102,9 +108,14 @@ export default function Result() {
                 />
                 <div>
                   <p className="text-lg font-semibold">{resumen.selected.titulo} <span className="text-muted-foreground">({resumen.selected.anio})</span></p>
+                  {resumen.selected.sinopsis && (
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {resumen.selected.sinopsis}
+                    </p>
+                  )}
                   {resumen.selected.datoCurioso && (
                     <p className="mt-2 text-sm text-muted-foreground">
-                      Dato curioso: {resumen.selected.datoCurioso}
+                      <span className="font-medium">¿Sabías que…?</span> {resumen.selected.datoCurioso}
                     </p>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- display book synopsis beneath the result title
- show fun fact block and expose it in JSON-LD

## Testing
- `npm run lint` *(fails: Unexpected any, Empty block statement, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_6896cfe6e4e8832993a893e386a1b1e0