### PR TITLE
Show transition animation only after start

### DIFF
--- a/src/components/Stairs/anim.js
+++ b/src/components/Stairs/anim.js
@@ -1,12 +1,15 @@
 export const expand = {
   initial: { height: 0 },
-  // Use a real height so the columns visibly expand from 0 to full size
-  animate: { height: "100%", transition: { duration: 0.5, delay: 0.2 } },
-  exit: { height: 0, transition: { duration: 0.5, delay: 0 } },
+  // Keep the columns collapsed until the exit animation is triggered
+  animate: { height: 0 },
+  // Expand to cover the screen when exiting the view
+  exit: { height: "100%", transition: { duration: 0.5, delay: 0 } },
 };
 
 export const opacity = {
   initial: { opacity: 0 },
-  animate: { opacity: 1, transition: { duration: 0.5, delay: 0.2 } },
-  exit: { opacity: 0, transition: { duration: 0.5, delay: 0 } },
+  // Hide the columns while the page is visible
+  animate: { opacity: 0 },
+  // Fade in the columns during the exit transition
+  exit: { opacity: 1, transition: { duration: 0.5, delay: 0 } },
 };

--- a/src/components/Stairs/index.jsx
+++ b/src/components/Stairs/index.jsx
@@ -6,14 +6,9 @@ const columns = Array.from({ length: nbOfColumns });
 
 const columnVariants = {
   initial: { ...expand.initial, ...opacity.initial },
-  animate: {
-    ...expand.animate,
-    ...opacity.animate,
-    transition: {
-      ...expand.animate.transition,
-      ...opacity.animate.transition,
-    },
-  },
+  // Keep columns invisible while the page is displayed
+  animate: { ...expand.animate, ...opacity.animate },
+  // Reveal the columns only when leaving the page
   exit: {
     ...expand.exit,
     ...opacity.exit,
@@ -56,6 +51,7 @@ const Layout = ({ children, backgroundColor }) => {
             gridRow: "1 / -1",
             position: "relative",
             zIndex: 10,
+            pointerEvents: "none",
           }}
         />
       ))}


### PR DESCRIPTION
## Summary
- Hide Stairs columns until the layout exits so transition plays only after clicking start.
- Disable pointer events on animation columns to keep start button accessible.

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, require import)*

------
https://chatgpt.com/codex/tasks/task_e_6896d7048a1c832999bc6fedba4cd846