### PR TITLE
style: use dark blue layout background

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,8 +19,8 @@ const Index = () => {
       onExitComplete={() => navigate("/preguntas")}
     >
       {!closing && (
-        // Use primary color with transparency for contrast against the page background
-        <Layout backgroundColor="hsl(var(--primary) / 0.6)">
+        // Use dark blue background color without transparency
+        <Layout backgroundColor="#00008B">
           <main>
             <Helmet>
               <title>¿Qué libro del club de lectura eres? |</title>

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -50,7 +50,9 @@ export default function Quiz() {
           selected: res.selected,
         },
       });
-    } catch {}
+    } catch {
+      // ignore errors ending session
+    }
     sessionStorage.setItem("quizResult", JSON.stringify({ answers, res }));
     navigate("/resultado");
   };
@@ -58,7 +60,7 @@ export default function Quiz() {
   const q = questions[current];
 
   return (
-    <Layout backgroundColor="hsl(var(--primary) / 0.6)" revealOnEnter>
+    <Layout backgroundColor="#00008B" revealOnEnter>
       <main className="min-h-screen bg-gradient-night flex flex-col">
         <Helmet>
           <title>Test lector – ¿Qué libro del club eres?</title>


### PR DESCRIPTION
## Summary
- use solid dark blue background for Index page transitions
- use solid dark blue background for Quiz page transitions

## Testing
- `npm test`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896f0ed0a40832997c3ae87f452f234