### PR TITLE
Fix exit animation and stable height for Stairs layout

### DIFF
--- a/src/components/Stairs/index.jsx
+++ b/src/components/Stairs/index.jsx
@@ -22,7 +22,8 @@ const Layout = ({ children, backgroundColor, revealOnEnter = false }) => {
           opacity: 1,
           transition: { duration: 0.65, ease: [0.22, 0.61, 0.36, 1] },
         },
-        exit: {},
+        // Ensure columns expand to full height when exiting
+        exit: { height: "100%" },
       }
     : {
         initial: { ...expand.initial, ...opacity.initial },
@@ -42,7 +43,7 @@ const Layout = ({ children, backgroundColor, revealOnEnter = false }) => {
       style={{
         display: "grid",
         gridTemplateColumns: `repeat(${nbOfColumns}, 1fr)`,
-        minHeight: "100vh", // ensure container spans full viewport height
+        height: "100vh", // ensure container spans full viewport height
       }}
       variants={containerVariants}
       initial="initial"

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { useParallax } from "@/components/hooks/useParallax";
 import Layout from "@/components/Stairs";
 import { AnimatePresence } from "framer-motion";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSession } from "@/hooks/use-session";
 
 const Index = () => {
@@ -13,6 +13,14 @@ const Index = () => {
   const [closing, setClosing] = useState(false);
   const { startSession } = useSession();
 
+  // Fallback navigation in case exit animation fails to trigger
+  useEffect(() => {
+    if (closing) {
+      const timer = setTimeout(() => navigate("/preguntas"), 650);
+      return () => clearTimeout(timer);
+    }
+  }, [closing, navigate]);
+
   return (
     <AnimatePresence
       mode="wait" // ensure exit animation completes before navigating
@@ -20,7 +28,7 @@ const Index = () => {
     >
       {!closing && (
         // Use dark blue background color without transparency
-        <Layout backgroundColor="#00008B">
+        <Layout key="layout" backgroundColor="#00008B">
           <main>
             <Helmet>
               <title>¿Qué libro del club de lectura eres? |</title>


### PR DESCRIPTION
## Summary
- add fallback navigation for closing animation and key for layout
- ensure Stairs container uses fixed viewport height and columns expand on exit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896f598891c8329b0e239e203e810ef