### PR TITLE
chore: add Supabase env template and validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copia este archivo a .env y completa los valores reales
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ src/integrations/supabase/client.ts
 # Environment variables
 .env
 .env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ npm i
 npm run dev
 ```
 
+## Variables de entorno
+
+Copia el archivo `.env.example` a `.env` y completa `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY` con los valores reales de tu proyecto en Supabase.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -16,22 +16,24 @@
  *   - score_details jsonb
  *   - created_at timestamp not null
  */
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-let supabase: SupabaseClient | null = null;
-
-if (supabaseUrl && supabaseAnonKey) {
-  supabase = createClient(supabaseUrl, supabaseAnonKey, {
-    auth: { persistSession: false },
-    global: { headers: { 'x-client-info': 'reading-club-quiz' } },
-  });
-} else if (typeof window !== 'undefined') {
-  console.warn(
-    '[Supabase] VITE_SUPABASE_URL o VITE_SUPABASE_ANON_KEY no están definidos. Las métricas no se guardarán hasta configurarlos.'
+if (!supabaseUrl) {
+  throw new Error(
+    '[Supabase] VITE_SUPABASE_URL no está definido. Copia .env.example a .env y configura la URL de tu proyecto.'
   );
 }
 
-export { supabase };
+if (!supabaseAnonKey) {
+  throw new Error(
+    '[Supabase] VITE_SUPABASE_ANON_KEY no está definido. Copia .env.example a .env y configura la clave anónima.'
+  );
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: { persistSession: false },
+  global: { headers: { 'x-client-info': 'reading-club-quiz' } },
+});


### PR DESCRIPTION
## Summary
- add `.env.example` template for Supabase configuration
- document copying `.env.example` in README
- verify Supabase env vars in `supabaseClient`

## Testing
- `VITE_SUPABASE_URL='http://localhost' VITE_SUPABASE_ANON_KEY='anon' npm test`


------
https://chatgpt.com/codex/tasks/task_e_689781a5ea348329bd3cef9914872f65