### PR TITLE
Update share button message and URL

### DIFF
--- a/src/__tests__/share-button.test.tsx
+++ b/src/__tests__/share-button.test.tsx
@@ -37,7 +37,7 @@ describe("ShareButton", () => {
       button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    expect(writeText).toHaveBeenCalledWith(window.location.href);
+    expect(writeText).toHaveBeenCalledWith(window.location.origin);
     expect(mockToast).toHaveBeenCalledWith({
       description: "¡Texto copiado al portapapeles!",
     });

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -9,10 +9,10 @@ export function ShareButton({ bookTitle }: ShareButtonProps) {
   const { toast } = useToast();
 
   const handleShare = async () => {
-    const url = window.location.href;
+    const url = window.location.origin;
     const data = {
       title: "Book Matchmaker",
-      text: `Me recomendaron "${bookTitle}"`,
+      text: `Hice el Quiz de Libros y me salió "${bookTitle}". Revisa qué libro te sale en quelibrodel.club`,
       url,
     };
 


### PR DESCRIPTION
## Summary
- Customize share message to promote quiz results and site link
- Share only the site origin instead of the full path
- Adjust tests to expect new clipboard behavior

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689811b3fec483299bf9267f2da77595