### PR TITLE
feat: add share modal fallback

### DIFF
--- a/src/__tests__/share-button.test.tsx
+++ b/src/__tests__/share-button.test.tsx
@@ -2,23 +2,13 @@
  * @vitest-environment jsdom
  */
 import React, { act } from "react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { createRoot } from "react-dom/client";
-
-const mockToast = vi.fn();
-vi.mock("@/hooks/use-toast", () => ({
-  useToast: () => ({ toast: mockToast }),
-}));
 
 import { ShareButton } from "@/components/ShareButton";
 
 describe("ShareButton", () => {
-  it("muestra un toast al copiar la URL", async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, "clipboard", {
-      value: { writeText },
-      configurable: true,
-    });
+  it("genera enlaces de fallback cuando navigator.share no está disponible", async () => {
     Object.defineProperty(navigator, "share", {
       value: undefined,
       configurable: true,
@@ -37,10 +27,18 @@ describe("ShareButton", () => {
       button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    expect(writeText).toHaveBeenCalledWith(window.location.origin);
-    expect(mockToast).toHaveBeenCalledWith({
-      description: "¡Texto copiado al portapapeles!",
-    });
+    const url = window.location.origin;
+    const message =
+      'Hice el Quiz de Libros y me salió "Test". Revisa qué libro te sale en quelibrodel.club';
+    const whatsapp = `https://wa.me/?text=${encodeURIComponent(message)}`;
+    const twitter = `https://twitter.com/intent/tweet?text=${encodeURIComponent(message)}`;
+    const facebook = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(
+      url
+    )}&quote=${encodeURIComponent(message)}`;
+
+    expect(document.querySelector(`a[href="${whatsapp}"]`)).toBeTruthy();
+    expect(document.querySelector(`a[href="${twitter}"]`)).toBeTruthy();
+    expect(document.querySelector(`a[href="${facebook}"]`)).toBeTruthy();
 
     root.unmount();
     container.remove();

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,18 +1,32 @@
+import { useState } from "react";
 import { Share2 } from "lucide-react";
-import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 interface ShareButtonProps {
   bookTitle: string;
 }
 
 export function ShareButton({ bookTitle }: ShareButtonProps) {
-  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+
+  const url = window.location.origin;
+  const message = `Hice el Quiz de Libros y me salió "${bookTitle}". Revisa qué libro te sale en quelibrodel.club`;
+  const shareLinks = {
+    whatsapp: `https://wa.me/?text=${encodeURIComponent(message)}`,
+    twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(message)}`,
+    facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}&quote=${encodeURIComponent(message)}`,
+  };
 
   const handleShare = async () => {
-    const url = window.location.origin;
     const data = {
       title: "Book Matchmaker",
-      text: `Hice el Quiz de Libros y me salió "${bookTitle}". Revisa qué libro te sale en quelibrodel.club`,
+      text: message,
       url,
     };
 
@@ -23,24 +37,58 @@ export function ShareButton({ bookTitle }: ShareButtonProps) {
       } catch {
         // ignore
       }
-    }
-
-    try {
-      await navigator.clipboard.writeText(url);
-      toast({ description: "¡Texto copiado al portapapeles!" });
-    } catch {
-      // ignore
+    } else {
+      setOpen(true);
     }
   };
 
   return (
-    <button
-      onClick={handleShare}
-      className="w-full bg-blue-500 hover:bg-blue-600 text-white font-medium py-3 px-4 rounded-xl shadow-md transform transition-all hover:scale-105 flex items-center justify-center gap-2 text-sm"
-    >
-      <Share2 className="w-4 h-4" />
-      Compartir
-    </button>
+    <>
+      <button
+        onClick={handleShare}
+        className="w-full bg-blue-500 hover:bg-blue-600 text-white font-medium py-3 px-4 rounded-xl shadow-md transform transition-all hover:scale-105 flex items-center justify-center gap-2 text-sm"
+      >
+        <Share2 className="w-4 h-4" />
+        Compartir
+      </button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Compartir</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-2">
+            <Button asChild variant="secondary">
+              <a
+                href={shareLinks.whatsapp}
+                target="_blank"
+                rel="noopener noreferrer"
+                autoFocus
+              >
+                WhatsApp
+              </a>
+            </Button>
+            <Button asChild variant="secondary">
+              <a
+                href={shareLinks.twitter}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                X/Twitter
+              </a>
+            </Button>
+            <Button asChild variant="secondary">
+              <a
+                href={shareLinks.facebook}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Facebook
+              </a>
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- open modal with social share links when `navigator.share` is unavailable
- test share link fallback rendering

## Testing
- `npm test`
- `npm run lint` *(fails: Fast refresh only works, no-empty-object-type, no-explicit-any, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_6898130b1ea0832994c53c97df9f0df7