### PR TITLE
fix: align profile section when exporting image

### DIFF
--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -163,6 +163,7 @@ export default function Result() {
     // Add reader profile section
     const profileMargin = 60;
     const profileY = currentY;
+    const profileX = margin + profileMargin;
     
     // Calculate profile content first to get proper height
     const emoji = mbtiEmojiMap[resumen.mbti] || "☕";
@@ -173,7 +174,7 @@ export default function Result() {
     // Profile background - covers entire section
     ctx.fillStyle = '#dbeafe'; // blue-100
     ctx.beginPath();
-    ctx.roundRect(profileMargin, profileY, contentWidth - (profileMargin * 2), profileHeight, 15);
+    ctx.roundRect(profileX, profileY, contentWidth - profileMargin * 2, profileHeight, 15);
     ctx.fill();
 
     // Profile emoji
@@ -190,7 +191,7 @@ export default function Result() {
     ctx.font = '24px Arial, sans-serif'; // Increased from 20px
     ctx.fillStyle = '#4b5563'; // gray-600
     let profileTextY = profileY + 140;
-    const textMargin = profileMargin; // Use consistent margin
+    const textMargin = profileX; // Use consistent margin
     const textWidth = contentWidth - (profileMargin * 2); // Simplified calculation
     
     profileLines.forEach((line, index) => {


### PR DESCRIPTION
## Summary
- center reader profile box relative to outer margin in export image
- align profile text with same horizontal offset

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a385bbb0348329aafa21f3a27771a9