### PR TITLE
feat: add html2canvas for result screenshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "^11.11.7",
+        "html2canvas": "^1.4.1",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -64,6 +65,7 @@
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@tailwindcss/typography": "^0.5.16",
+        "@types/html2canvas": "^1.0.0",
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
@@ -3121,6 +3123,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/html2canvas": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/html2canvas/-/html2canvas-1.0.0.tgz",
+      "integrity": "sha512-BJpVf+FIN9UERmzhbtUgpXj6XBZpG67FMgBLLoj9HZKd9XifcCpSV+UnFcwTZfEyun4U/KmCrrVOG7829L589w==",
+      "deprecated": "This is a stub types definition. html2canvas provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "html2canvas": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3742,6 +3755,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4021,6 +4043,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -4972,6 +5003,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -7139,6 +7183,15 @@
         "tailwindcss": ">=3.0.0 || insiders"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -7486,6 +7539,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vaul": {
       "version": "0.9.9",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^11.11.7",
+    "html2canvas": "^1.4.1",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
@@ -68,6 +69,7 @@
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@types/html2canvas": "^1.0.0",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -5,6 +5,7 @@ import { Sparkles, RefreshCw, ArrowLeft, Download } from "lucide-react";
 import type { ComputedResult, FinalSelection } from "@/lib/quiz/scoring";
 import { placeholderMap } from "@/lib/results/coverPlaceholders";
 import { ShareButton } from "@/components/ShareButton";
+import html2canvas from "html2canvas";
 
 function getCoverPlaceholder(title: string) {
   const index = placeholderMap[title as keyof typeof placeholderMap];
@@ -78,171 +79,15 @@ export default function Result() {
 
   const generateDownloadImage = async () => {
     if (!resumen) return;
-
-    const canvas = document.createElement('canvas');
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
-    // Set canvas dimensions for vertical layout
-    canvas.width = 800;
-    canvas.height = 1200;
-
-    // Create gradient background
-    const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
-    gradient.addColorStop(0, '#fef3c7'); // amber-100
-    gradient.addColorStop(0.5, '#fef3c7'); // amber-100
-    gradient.addColorStop(1, '#fed7aa'); // orange-200
-    ctx.fillStyle = gradient;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    // Add rounded rectangle for main content
-    const margin = 40;
-    const contentWidth = canvas.width - (margin * 2);
-    const contentHeight = canvas.height - (margin * 2);
-    
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.9)';
-    ctx.beginPath();
-    ctx.roundRect(margin, margin, contentWidth, contentHeight, 20);
-    ctx.fill();
-
-    let currentY = margin + 60;
-
-    // Add title
-    ctx.fillStyle = '#92400e'; // amber-800
-    ctx.font = 'bold 42px Arial, sans-serif';
-    ctx.textAlign = 'center';
-    
-    const titleLines = wrapText(ctx, resumen.selected.titulo, contentWidth - 80);
-    titleLines.forEach(line => {
-      ctx.fillText(line, canvas.width / 2, currentY);
-      currentY += 50;
-    });
-
-    // Add author
-    currentY += 20;
-    ctx.font = '28px Arial, sans-serif';
-    ctx.fillStyle = '#a16207'; // amber-700
-    ctx.fillText(`${resumen.selected.autor} (${resumen.selected.anio})`, canvas.width / 2, currentY);
-
-    // Load and draw book cover
-    try {
-      const img = new Image();
-      img.crossOrigin = 'anonymous';
-      await new Promise((resolve, reject) => {
-        img.onload = resolve;
-        img.onerror = reject;
-        img.src = coverSrc;
-      });
-
-      currentY += 60;
-      const bookWidth = 280; // Increased from 240
-      const bookHeight = 420; // Increased from 360
-      const bookX = (canvas.width - bookWidth) / 2;
-      
-      // Add shadow for book
-      ctx.shadowColor = 'rgba(0, 0, 0, 0.3)';
-      ctx.shadowBlur = 15;
-      ctx.shadowOffsetX = 5;
-      ctx.shadowOffsetY = 5;
-      
-      ctx.drawImage(img, bookX, currentY, bookWidth, bookHeight);
-      
-      // Reset shadow
-      ctx.shadowColor = 'transparent';
-      ctx.shadowBlur = 0;
-      ctx.shadowOffsetX = 0;
-      ctx.shadowOffsetY = 0;
-
-      currentY += bookHeight + 60;
-
-    } catch (error) {
-      console.error('Error loading book cover:', error);
-      currentY += 480; // Adjusted for larger book space
-    }
-
-    // Add reader profile section
-    const profileMargin = 60;
-    const profileWidth = contentWidth - profileMargin * 2;
-    const profileY = currentY;
-    const profileX = (canvas.width - profileWidth) / 2;
-
-    // Calculate profile content first to get proper height
-    const emoji = mbtiEmojiMap[resumen.mbti] || "☕";
-    ctx.font = '24px Arial, sans-serif'; // Use the larger font size for calculation
-    const profileLines = wrapText(ctx, frase, profileWidth);
-    const profileHeight = 120 + (profileLines.length * 30) + 40; // Adjusted for larger text and spacing
-
-    // Profile background - covers entire section
-    ctx.fillStyle = '#dbeafe'; // blue-100
-    ctx.beginPath();
-    ctx.roundRect(profileX, profileY, profileWidth, profileHeight, 15);
-    ctx.fill();
-
-    // Profile emoji
-    ctx.font = '50px Arial, sans-serif'; // Increased from 40px
-    ctx.textAlign = 'center';
-    ctx.fillText(emoji, canvas.width / 2, profileY + 55);
-
-    // Profile title
-    ctx.font = 'bold 32px Arial, sans-serif'; // Increased from 24px
-    ctx.fillStyle = '#374151'; // gray-700
-    ctx.fillText('Tu perfil lector', canvas.width / 2, profileY + 105);
-
-    // Profile text - centered and justified
-    ctx.font = '24px Arial, sans-serif'; // Increased from 20px
-    ctx.fillStyle = '#4b5563'; // gray-600
-    let profileTextY = profileY + 140;
-    const textMargin = profileX; // Use consistent margin
-    const textWidth = profileWidth; // Simplified calculation
-    
-    profileLines.forEach((line, index) => {
-      // Center the text block by calculating proper starting position
-      ctx.textAlign = 'left';
-      
-      // For justified text (except last line), distribute spaces evenly
-      if (index < profileLines.length - 1 && line.split(' ').length > 1) {
-        const words = line.split(' ');
-        const totalTextWidth = words.reduce((acc, word) => acc + ctx.measureText(word).width, 0);
-        const spaceWidth = (textWidth - totalTextWidth) / (words.length - 1);
-        
-        let x = textMargin;
-        words.forEach((word, wordIndex) => {
-          ctx.fillText(word, x, profileTextY);
-          x += ctx.measureText(word).width + (wordIndex < words.length - 1 ? spaceWidth : 0);
-        });
-      } else {
-        // Last line - center aligned
-        ctx.textAlign = 'center';
-        ctx.fillText(line, canvas.width / 2, profileTextY);
-      }
-      profileTextY += 30; // Increased spacing for larger text
-    });
-
-    // Download the image
-    const link = document.createElement('a');
+    const element = document.getElementById("result-card");
+    if (!element) return;
+    const canvas = await html2canvas(element, { useCORS: true, backgroundColor: "#ffffff" });
+    const link = document.createElement("a");
     link.download = `mi-libro-recomendado-${resumen.selected.titulo.replace(/[^a-zA-Z0-9]/g, '-')}.png`;
-    link.href = canvas.toDataURL();
+    link.href = canvas.toDataURL("image/png");
     link.click();
   };
 
-  const wrapText = (ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] => {
-    const words = text.split(' ');
-    const lines: string[] = [];
-    let currentLine = words[0];
-
-    for (let i = 1; i < words.length; i++) {
-      const testLine = currentLine + ' ' + words[i];
-      const metrics = ctx.measureText(testLine);
-      if (metrics.width > maxWidth) {
-        lines.push(currentLine);
-        currentLine = words[i];
-      } else {
-        currentLine = testLine;
-      }
-    }
-    lines.push(currentLine);
-    return lines;
-  };
 
   if (!resumen) {
     return (
@@ -298,7 +143,7 @@ export default function Result() {
           <div className="w-16 sm:w-20 lg:w-24"></div> {/* Spacer for symmetry */}
         </div>
 
-        <div className="bg-amber-50/90 backdrop-blur-sm rounded-2xl shadow-xl overflow-hidden border border-amber-200/50">
+        <div id="result-card" className="bg-amber-50/90 backdrop-blur-sm rounded-2xl shadow-xl overflow-hidden border border-amber-200/50">
           <div className="p-4 sm:p-5 lg:p-6">
             <div className="space-y-4">
               {/* Título */}


### PR DESCRIPTION
## Summary
- add html2canvas and its types to the project
- enable downloading the result card using html2canvas

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e1f752448329abe1fa565a53845e