### PR TITLE
feat: expose author and synopsis markers

### DIFF
--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -158,13 +158,13 @@ export default function Result() {
                 </div>
 
                 {/* Autor */}
-                <div className="bg-gradient-to-r from-amber-600 via-yellow-700 to-orange-700 rounded-xl p-3 text-center">
+                <div className="author-container bg-gradient-to-r from-amber-600 via-yellow-700 to-orange-700 rounded-xl p-3 text-center">
                   <span className="text-amber-50 font-medium text-sm lg:text-base">{`${resumen.selected.autor} (${resumen.selected.anio})`}</span>
                 </div>
 
                 {/* Sinopsis */}
                 {resumen.selected.sinopsis && (
-                  <div className="bg-gradient-to-br from-amber-600 via-yellow-700 to-orange-700 rounded-xl p-4">
+                  <div className="synopsis-container bg-gradient-to-br from-amber-600 via-yellow-700 to-orange-700 rounded-xl p-4">
                     <h3 className="text-amber-50 font-semibold text-center mb-4 text-base lg:text-lg">Sinopsis</h3>
                     <p className="text-amber-50/90 text-sm lg:text-base leading-relaxed text-center">
                       {resumen.selected.sinopsis}


### PR DESCRIPTION
## Summary
- add dedicated author and synopsis markers on result page for sharing

## Testing
- `npm test` *(fails: Not implemented navigation in jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d5e166688329ae5b8f85ca6041dc