### PR TITLE
fix: enforce two-column layout on result page

### DIFF
--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -137,7 +137,7 @@ export default function Result() {
 
         <div className="bg-amber-50/90 backdrop-blur-sm rounded-2xl shadow-xl overflow-hidden border border-amber-200/50 max-w-4xl mx-auto">
           <div className="p-4 sm:p-5 lg:p-6 max-w-3xl mx-auto">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 max-w-4xl mx-auto">
+            <div className="grid grid-cols-2 gap-4 max-w-4xl mx-auto">
               {/* Portada */}
               <div className="bg-gradient-to-br from-amber-600 via-yellow-700 to-orange-700 rounded-xl p-3 flex items-center justify-center max-w-full mx-auto">
                 <div className="bg-amber-50 p-2 rounded-lg shadow-lg">


### PR DESCRIPTION
## Summary
- enforce two-column layout on result page

## Testing
- `npm test` *(fails: Cannot read properties of null (reading 'dispatchEvent'))*

------
https://chatgpt.com/codex/tasks/task_e_68a5e6eacefc83298cdf83582fbe766b