### PR TITLE
Mejora visual de la barra de progreso del quiz

### DIFF
--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -10,13 +10,13 @@ const Progress = React.forwardRef<
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      "relative h-2.5 w-full overflow-hidden rounded-full bg-card-foreground/15",
       className
     )}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-gradient-to-r from-accent to-primary transition-all"
+      className="h-full w-full flex-1 bg-gradient-to-r from-[hsl(29_85%_48%)] via-accent to-[hsl(35_72%_72%)] transition-all duration-500 shadow-[0_0_8px_hsl(29_70%_52%/0.6)]"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>


### PR DESCRIPTION
Reemplaza el fondo teal (bg-secondary) por un track sutil oscuro que contrasta bien con el card cálido; el indicador usa un gradiente naranja ámbar con glow suave para que se distinga claramente incluso al 6%.


Claude-Session: https://claude.ai/code/session_01Jkx5X2MCv4b7N3eTXy1HqT